### PR TITLE
fix(news-sync): resolve 504/502 by decoupling enrichment and hardening execution

### DIFF
--- a/.github/workflows/news-sync.yml
+++ b/.github/workflows/news-sync.yml
@@ -18,6 +18,7 @@ jobs:
       - name: Trigger news sync
         run: |
           STATUS=$(curl -s -o /tmp/resp.json -w "%{http_code}" \
+            --max-time 30 \
             -X POST \
             -H "Authorization: Bearer ${{ secrets.CRON_SECRET }}" \
             -H "Content-Type: application/json" \
@@ -29,5 +30,23 @@ jobs:
 
           if [ "$STATUS" != "200" ]; then
             echo "Sync failed with HTTP $STATUS"
+            exit 1
+          fi
+
+      - name: Enrich cached post content
+        run: |
+          STATUS=$(curl -s -o /tmp/resp-enrich.json -w "%{http_code}" \
+            --max-time 30 \
+            -X POST \
+            -H "Authorization: Bearer ${{ secrets.CRON_SECRET }}" \
+            -H "Content-Type: application/json" \
+            https://prana-wijaya.netlify.app/api/news/enrich)
+
+          echo "HTTP Status: $STATUS"
+          echo "Response:"
+          cat /tmp/resp-enrich.json
+
+          if [ "$STATUS" != "200" ]; then
+            echo "Enrich failed with HTTP $STATUS"
             exit 1
           fi

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,6 +5,7 @@
 [functions]
   directory = ".netlify/functions-internal"
   node_bundler = "esbuild"
+  timeout = 26
 
 [build.environment]
   NODE_VERSION = "22"

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,7 +5,6 @@
 [functions]
   directory = ".netlify/functions-internal"
   node_bundler = "esbuild"
-  timeout = 26
 
 [build.environment]
   NODE_VERSION = "22"

--- a/server/api/news/enrich.post.ts
+++ b/server/api/news/enrich.post.ts
@@ -5,7 +5,7 @@ import { buildSafeSourceLink, getNotionCoverUrl, isSafeRemoteUrl } from '../../u
 
 const NOTION_API = 'https://api.notion.com/v1'
 const NOTION_VERSION = '2022-06-28'
-const ENRICH_BUDGET_MS = 22_000
+const ENRICH_BUDGET_MS = 8_000
 const ENRICH_FETCH_TIMEOUT_MS = 6_000
 const NOTION_API_TIMEOUT_MS = 4_000
 const NOTION_RATE_LIMIT_MS = 350

--- a/server/api/news/enrich.post.ts
+++ b/server/api/news/enrich.post.ts
@@ -1,0 +1,184 @@
+import { generateSlug } from '../../utils/slug'
+import { fetchContentFromUrl } from '../../utils/content-fetcher'
+import { setCachedPost } from '../../utils/post-store'
+import { buildSafeSourceLink, getNotionCoverUrl, isSafeRemoteUrl } from '../../utils/content-security'
+
+const NOTION_API = 'https://api.notion.com/v1'
+const NOTION_VERSION = '2022-06-28'
+const ENRICH_BUDGET_MS = 22_000
+const ENRICH_FETCH_TIMEOUT_MS = 6_000
+const NOTION_API_TIMEOUT_MS = 4_000
+const NOTION_RATE_LIMIT_MS = 350
+
+interface NotionRichText {
+  type?: string
+  text?: { content?: string; link?: { url: string } | null }
+  plain_text?: string
+  href?: string | null
+}
+
+interface NotionBlock {
+  id: string
+  type: string
+  paragraph?: { rich_text?: NotionRichText[] }
+}
+
+interface NotionBlocksResponse {
+  results: NotionBlock[]
+}
+
+interface NotionPage {
+  id: string
+  properties: Record<string, any>
+}
+
+function assertAuth(event: Parameters<typeof getHeader>[0], secret: string) {
+  const header = getHeader(event, 'authorization') ?? ''
+  if (!secret || header !== `Bearer ${secret}`) {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  }
+}
+
+function getTitle(page: NotionPage): string {
+  const prop = page.properties?.Name ?? page.properties?.Title ?? page.properties?.title ?? page.properties?.['title']
+  return prop?.title?.[0]?.plain_text ?? ''
+}
+
+function getTags(page: NotionPage): string[] {
+  const prop = page.properties?.tags ?? page.properties?.Tags
+  return Array.isArray(prop?.multi_select)
+    ? prop.multi_select.map((tag: { name?: string }) => tag.name).filter(Boolean)
+    : []
+}
+
+function getDescription(page: NotionPage): string {
+  const prop = page.properties?.description ?? page.properties?.Description
+  const nodes = Array.isArray(prop?.rich_text) ? prop.rich_text : []
+  return nodes.map((node: { plain_text?: string }) => node.plain_text ?? '').join('').trim()
+}
+
+async function fetchRecentDevToPages(token: string, dbId: string): Promise<NotionPage[]> {
+  const since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString()
+  const res = await fetch(`${NOTION_API}/databases/${dbId}/query`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Notion-Version': NOTION_VERSION,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      page_size: 100,
+      filter: {
+        and: [
+          {
+            property: 'created_at',
+            date: { on_or_after: since },
+          },
+          {
+            property: 'tags',
+            multi_select: { contains: 'dev-to' },
+          },
+        ],
+      },
+    }),
+    signal: AbortSignal.timeout(NOTION_API_TIMEOUT_MS),
+  })
+
+  if (!res.ok) return []
+  const data = (await res.json()) as { results?: NotionPage[] }
+  return data.results ?? []
+}
+
+async function getSourceUrlFromPage(token: string, pageId: string): Promise<string | null> {
+  const res = await fetch(`${NOTION_API}/blocks/${pageId}/children?page_size=10`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Notion-Version': NOTION_VERSION,
+    },
+    signal: AbortSignal.timeout(NOTION_API_TIMEOUT_MS),
+  })
+  if (!res.ok) return null
+
+  const data = (await res.json()) as NotionBlocksResponse
+  for (const block of data.results ?? []) {
+    if (block.type !== 'paragraph') continue
+    const rt = block.paragraph?.rich_text ?? []
+    const linkUrl = rt[1]?.text?.link?.url ?? rt[1]?.href ?? null
+    if (linkUrl) return linkUrl
+    for (const node of rt) {
+      const u = node?.text?.link?.url ?? node?.href ?? null
+      if (u) return u
+    }
+  }
+  return null
+}
+
+export default defineEventHandler(async (event) => {
+  const config = useRuntimeConfig()
+  assertAuth(event, config.cronSecret ?? '')
+
+  const notionToken = config.notionToken
+  const dbId = config.public.notionTableId
+
+  if (!notionToken) {
+    throw createError({ statusCode: 500, statusMessage: 'NOTION_TOKEN not configured' })
+  }
+  if (!dbId) {
+    throw createError({ statusCode: 500, statusMessage: 'NOTION_TABLE_ID not configured' })
+  }
+
+  const deadline = Date.now() + ENRICH_BUDGET_MS
+  const pages = await fetchRecentDevToPages(notionToken, dbId)
+
+  let enriched = 0
+  let skipped = 0
+  let errors = 0
+  let budgetExhausted = false
+
+  for (const page of pages) {
+    if (Date.now() >= deadline) {
+      budgetExhausted = true
+      break
+    }
+
+    try {
+      const sourceUrl = await getSourceUrlFromPage(notionToken, page.id)
+      if (!sourceUrl || !isSafeRemoteUrl(sourceUrl)) {
+        skipped++
+        continue
+      }
+
+      const content = await fetchContentFromUrl(sourceUrl, ENRICH_FETCH_TIMEOUT_MS)
+      if (!content) {
+        skipped++
+        continue
+      }
+
+      const title = getTitle(page)
+      if (!title) {
+        skipped++
+        continue
+      }
+
+      const slug = generateSlug(title)
+      await setCachedPost(slug, {
+        slug,
+        title,
+        content: `${buildSafeSourceLink(sourceUrl)}${content.content}`,
+        thumbnail: content.thumbnail || getNotionCoverUrl(page),
+        excerpt: content.excerpt || getDescription(page),
+        created_at: new Date().toISOString(),
+        tags: getTags(page),
+      })
+
+      enriched++
+      await new Promise((r) => setTimeout(r, NOTION_RATE_LIMIT_MS))
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err)
+      console.error(`enrich failed for page ${page.id}:`, msg)
+      errors++
+    }
+  }
+
+  return { enriched, skipped, errors, scanned: pages.length, budgetExhausted }
+})

--- a/server/api/news/sync.post.ts
+++ b/server/api/news/sync.post.ts
@@ -150,7 +150,7 @@ async function createNotionPage(notion: Client, dbId: string, article: Article):
         rich_text: [{ text: { content: article.description.slice(0, 2000) } }],
       },
       public: {
-        checkbox: false,
+        checkbox: true,
       },
       created_at: {
         date: { start: new Date().toISOString() },

--- a/server/api/news/sync.post.ts
+++ b/server/api/news/sync.post.ts
@@ -1,8 +1,8 @@
 import { Client } from '@notionhq/client'
-import { generateSlug } from '../../utils/slug'
-import { fetchContentFromUrl } from '../../utils/content-fetcher'
-import { setCachedPost } from '../../utils/post-store'
 
+const SYNC_BUDGET_MS = 22_000
+const EXTERNAL_FETCH_TIMEOUT_MS = 4_000
+const NOTION_RATE_LIMIT_MS = 350
 const HN_API = 'https://hacker-news.firebaseio.com/v0'
 const DEVTO_API = 'https://dev.to/api'
 const NOTION_API = 'https://api.notion.com/v1'
@@ -23,53 +23,73 @@ function assertAuth(event: Parameters<typeof getHeader>[0], secret: string) {
 }
 
 async function fetchHackerNews(): Promise<Article[]> {
-  const res = await fetch(`${HN_API}/topstories.json`)
-  if (!res.ok) return []
-  const ids: number[] = await res.json()
+  try {
+    const res = await fetch(`${HN_API}/topstories.json`, {
+      signal: AbortSignal.timeout(EXTERNAL_FETCH_TIMEOUT_MS),
+    })
+    if (!res.ok) return []
+    const ids: number[] = await res.json()
 
-  const results: Article[] = []
-  for (let i = 0; i < 80 && results.length < 20; i += 10) {
-    const batch = ids.slice(i, i + 10)
-    const items = await Promise.all(
-      batch.map(id =>
-        fetch(`${HN_API}/item/${id}.json`).then(r => (r.ok ? r.json() : null))
+    const results: Article[] = []
+    for (let i = 0; i < 80 && results.length < 20; i += 10) {
+      const batch = ids.slice(i, i + 10)
+      const items = await Promise.all(
+        batch.map(async (id) => {
+          try {
+            const response = await fetch(`${HN_API}/item/${id}.json`, {
+              signal: AbortSignal.timeout(EXTERNAL_FETCH_TIMEOUT_MS),
+            })
+            return response.ok ? response.json() : null
+          } catch {
+            return null
+          }
+        })
       )
-    )
-    for (const item of items) {
-      if (!item || item.type !== 'story' || !item.url) continue
-      if ((item.score ?? 0) < 50) continue
-      results.push({
-        title: item.title ?? 'Untitled',
-        url: item.url,
-        description: `HN score: ${item.score} · by ${item.by ?? 'unknown'}`,
-        tags: ['hacker-news', 'tech'],
-      })
+      for (const item of items) {
+        if (!item || item.type !== 'story' || !item.url) continue
+        if ((item.score ?? 0) < 50) continue
+        results.push({
+          title: item.title ?? 'Untitled',
+          url: item.url,
+          description: `HN score: ${item.score} · by ${item.by ?? 'unknown'}`,
+          tags: ['hacker-news', 'tech'],
+        })
+      }
     }
+    return results
+  } catch {
+    return []
   }
-  return results
 }
 
 async function fetchDevTo(): Promise<Article[]> {
   const TAGS = ['ai', 'javascript', 'programming']
   const results: Article[] = []
   for (const tag of TAGS) {
-    const res = await fetch(
-      `${DEVTO_API}/articles?tag=${tag}&per_page=5&top=7`,
-      { headers: { 'User-Agent': 'prana-portfolio/newssync' } }
-    )
-    if (!res.ok) continue
-    const articles: Array<{
-      title: string; url: string; description?: string
-      cover_image?: string; social_image?: string
-    }> = await res.json()
-    for (const a of articles) {
-      results.push({
-        title: a.title,
-        url: a.url,
-        description: a.description ?? '',
-        tags: [tag, 'dev-to'],
-        thumbnail: a.cover_image || a.social_image || '',
-      })
+    try {
+      const res = await fetch(
+        `${DEVTO_API}/articles?tag=${tag}&per_page=5&top=7`,
+        {
+          headers: { 'User-Agent': 'prana-portfolio/newssync' },
+          signal: AbortSignal.timeout(EXTERNAL_FETCH_TIMEOUT_MS),
+        }
+      )
+      if (!res.ok) continue
+      const articles: Array<{
+        title: string; url: string; description?: string
+        cover_image?: string; social_image?: string
+      }> = await res.json()
+      for (const a of articles) {
+        results.push({
+          title: a.title,
+          url: a.url,
+          description: a.description ?? '',
+          tags: [tag, 'dev-to'],
+          thumbnail: a.cover_image || a.social_image || '',
+        })
+      }
+    } catch {
+      continue
     }
   }
   return results
@@ -91,6 +111,7 @@ async function getExistingTitles(token: string, dbId: string): Promise<Set<strin
         'Content-Type': 'application/json',
       },
       body: JSON.stringify(body),
+      signal: AbortSignal.timeout(EXTERNAL_FETCH_TIMEOUT_MS),
     })
     if (!res.ok) break
 
@@ -174,6 +195,8 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 500, statusMessage: 'NOTION_TABLE_ID not configured' })
   }
 
+  const deadline = Date.now() + SYNC_BUDGET_MS
+
   const [hnArticles, devtoArticles] = await Promise.all([
     fetchHackerNews(),
     fetchDevTo(),
@@ -192,8 +215,13 @@ export default defineEventHandler(async (event) => {
 
   let added = 0
   let skipped = 0
+  let budgetExhausted = false
 
   for (const article of allArticles) {
+    if (Date.now() >= deadline) {
+      budgetExhausted = true
+      break
+    }
     const key = article.title.toLowerCase().trim()
     if (existingTitles.has(key)) {
       skipped++
@@ -203,27 +231,12 @@ export default defineEventHandler(async (event) => {
       await createNotionPage(notion, dbId, article)
       existingTitles.add(key)
       added++
-      if (article.url.includes('dev.to/')) {
-        const enriched = await fetchContentFromUrl(article.url)
-        if (enriched) {
-          const slug = generateSlug(article.title)
-          await setCachedPost(slug, {
-            slug,
-            title: article.title,
-            content: `<p><a href="${article.url}" target="_blank" rel="noopener noreferrer">🔗 Read original article</a></p>\n` + enriched.content,
-            thumbnail: enriched.thumbnail || article.thumbnail || '',
-            excerpt: enriched.excerpt || article.description,
-            created_at: new Date().toISOString(),
-            tags: article.tags,
-          })
-        }
-      }
-      await new Promise(r => setTimeout(r, 350))
+      await new Promise(r => setTimeout(r, NOTION_RATE_LIMIT_MS))
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err)
       console.error(`Notion create failed for "${article.title}":`, msg)
     }
   }
 
-  return { added, skipped, total: allArticles.length }
+  return { added, skipped, total: allArticles.length, budgetExhausted }
 })

--- a/server/api/news/sync.post.ts
+++ b/server/api/news/sync.post.ts
@@ -1,6 +1,6 @@
 import { Client } from '@notionhq/client'
 
-const SYNC_BUDGET_MS = 22_000
+const SYNC_BUDGET_MS = 8_000
 const EXTERNAL_FETCH_TIMEOUT_MS = 4_000
 const NOTION_RATE_LIMIT_MS = 350
 const HN_API = 'https://hacker-news.firebaseio.com/v0'

--- a/server/api/posts/[slug].ts
+++ b/server/api/posts/[slug].ts
@@ -3,6 +3,7 @@ import { join } from 'path'
 import { generateSlug } from '../../utils/slug'
 import { getCachedPost, setCachedPost } from '../../utils/post-store'
 import { fetchContentFromUrl } from '../../utils/content-fetcher'
+import { buildSafeSourceLink, getNotionCoverUrl, isSafeRemoteUrl } from '../../utils/content-security'
 
 const ARTICLES_DIR = join(process.cwd(), 'server/data/articles')
 const NOTION_API = 'https://api.notion.com/v1'
@@ -126,7 +127,9 @@ export default defineEventHandler(async (event) => {
     }
   }
 
-  if (!sourceUrl) throw createError({ statusCode: 404, statusMessage: 'Post content not available yet' })
+  if (!sourceUrl || !isSafeRemoteUrl(sourceUrl)) {
+    throw createError({ statusCode: 404, statusMessage: 'Post content not available yet' })
+  }
 
   const enriched = await fetchContentFromUrl(sourceUrl)
   if (!enriched) throw createError({ statusCode: 503, statusMessage: 'Could not fetch article content' })
@@ -136,16 +139,13 @@ export default defineEventHandler(async (event) => {
     multi_select?: Array<{ name: string }>
     date?: { start: string }
   }>
-  const cover = matchedPage.cover as { external?: { url: string }; file?: { url: string } } | null
   const description = props.description?.rich_text?.[0]?.plain_text ?? ''
   const tags = props.tags?.multi_select?.map(t => t.name) ?? []
   const createdAt = new Date(
     (props.created_at?.date?.start ?? matchedPage.created_time) as string
   ).toISOString()
-  const thumbnail = cover?.external?.url || cover?.file?.url || enriched.thumbnail || ''
-  const content =
-    `<p><a href="${sourceUrl}" target="_blank" rel="noopener noreferrer">🔗 Read original article</a></p>\n` +
-    enriched.content
+  const thumbnail = getNotionCoverUrl(matchedPage) || enriched.thumbnail || ''
+  const content = buildSafeSourceLink(sourceUrl) + enriched.content
 
   const stored = {
     slug, title: matchedTitle, content, thumbnail,

--- a/server/utils/content-fetcher.ts
+++ b/server/utils/content-fetcher.ts
@@ -1,5 +1,6 @@
 import { Readability } from '@mozilla/readability'
 import { parseHTML } from 'linkedom'
+import { isSafeRemoteUrl, sanitizeRemoteHtml } from './content-security'
 
 export interface EnrichedContent {
   content: string
@@ -7,20 +8,20 @@ export interface EnrichedContent {
   excerpt: string
 }
 
-async function fetchDevToContent(url: string): Promise<EnrichedContent | null> {
+async function fetchDevToContent(url: string, timeoutMs: number): Promise<EnrichedContent | null> {
   const match = url.match(/dev\.to\/([^/]+)\/([^/?#]+)/)
   if (!match) return null
   const [, username, slug] = match
   try {
     const res = await fetch(`https://dev.to/api/articles/${username}/${slug}`, {
       headers: { 'User-Agent': 'prana-portfolio/1.0' },
-      signal: AbortSignal.timeout(10000),
+      signal: AbortSignal.timeout(timeoutMs),
     })
     if (!res.ok) return null
     const data = await res.json()
     if (!data.body_html || (data.body_html as string).replace(/<[^>]+>/g, '').trim().length < 200) return null
     return {
-      content: data.body_html as string,
+      content: sanitizeRemoteHtml(data.body_html as string),
       thumbnail: (data.cover_image || data.social_image || '') as string,
       excerpt: (data.description || '') as string,
     }
@@ -29,11 +30,12 @@ async function fetchDevToContent(url: string): Promise<EnrichedContent | null> {
   }
 }
 
-async function fetchReadabilityContent(url: string): Promise<EnrichedContent | null> {
+async function fetchReadabilityContent(url: string, timeoutMs: number): Promise<EnrichedContent | null> {
+  if (!isSafeRemoteUrl(url)) return null
   try {
     const res = await fetch(url, {
       headers: { 'User-Agent': 'Mozilla/5.0 (compatible; portfolio-fetcher/1.0)' },
-      signal: AbortSignal.timeout(12000),
+      signal: AbortSignal.timeout(timeoutMs),
     })
     if (!res.ok) return null
     const html = await res.text()
@@ -42,7 +44,7 @@ async function fetchReadabilityContent(url: string): Promise<EnrichedContent | n
     const article = reader.parse()
     if (!article?.content || article.content.replace(/<[^>]+>/g, '').trim().length < 200) return null
     return {
-      content: article.content,
+      content: sanitizeRemoteHtml(article.content),
       thumbnail: '',
       excerpt: article.excerpt || '',
     }
@@ -51,10 +53,10 @@ async function fetchReadabilityContent(url: string): Promise<EnrichedContent | n
   }
 }
 
-export async function fetchContentFromUrl(url: string): Promise<EnrichedContent | null> {
+export async function fetchContentFromUrl(url: string, timeoutMs = 10_000): Promise<EnrichedContent | null> {
   if (url.includes('dev.to/')) {
-    const result = await fetchDevToContent(url)
+    const result = await fetchDevToContent(url, timeoutMs)
     if (result) return result
   }
-  return fetchReadabilityContent(url)
+  return fetchReadabilityContent(url, timeoutMs)
 }

--- a/server/utils/content-security.ts
+++ b/server/utils/content-security.ts
@@ -1,0 +1,60 @@
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+function stripDangerousAttributes(html: string): string {
+  return html
+    .replace(/\s*on[a-z]+\s*=\s*("[^"]*"|'[^']*'|[^\s>]+)/gi, '')
+    .replace(/(href|src|action|formaction|ping|srcdoc)\s*=\s*(?:"\s*(?:javascript:|data:|vbscript:)[^"]*"|'\s*(?:javascript:|data:|vbscript:)[^']*'|\s*(?:javascript:|data:|vbscript:)[^\s>]+)/gi, '$1="#"')
+}
+
+function stripDangerousElements(html: string): string {
+  return html
+    .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
+    .replace(/<iframe\b[^<]*(?:(?!<\/iframe>)<[^<]*)*<\/iframe>/gi, '')
+    .replace(/<object\b[^<]*(?:(?!<\/object>)<[^<]*)*<\/object>/gi, '')
+    .replace(/<embed\b[^>]*>/gi, '')
+}
+
+function stripUnsafeSchemes(html: string): string {
+  return html
+    .replace(/(?:javascript:|data:text\/html|vbscript:)/gi, '')
+}
+
+export function sanitizeRemoteHtml(html: string): string {
+  return stripUnsafeSchemes(stripDangerousAttributes(stripDangerousElements(html)))
+}
+
+export function isSafeRemoteUrl(value: string): boolean {
+  try {
+    const url = new URL(value)
+    if (url.protocol !== 'https:') return false
+
+    const host = url.hostname.toLowerCase()
+    if (host === 'localhost' || host === '0.0.0.0' || host === '::1' || host === '[::1]') return false
+    if (/^127\./.test(host)) return false
+    if (/^10\./.test(host)) return false
+    if (/^192\.168\./.test(host)) return false
+    if (/^169\.254\./.test(host)) return false
+    if (/^172\.(1[6-9]|2\d|3[0-1])\./.test(host)) return false
+
+    return true
+  } catch {
+    return false
+  }
+}
+
+export function buildSafeSourceLink(url: string): string {
+  if (!isSafeRemoteUrl(url)) return ''
+  const safeUrl = escapeHtml(url)
+  return `<p><a href="${safeUrl}" target="_blank" rel="noopener noreferrer">🔗 Read original article</a></p>\n`
+}
+
+export function getNotionCoverUrl(page: { cover?: { external?: { url?: string }; file?: { url?: string } } | null }): string {
+  return page.cover?.external?.url || page.cover?.file?.url || ''
+}

--- a/tests/news-security.test.mjs
+++ b/tests/news-security.test.mjs
@@ -1,0 +1,56 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import jitiFactory from 'jiti'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const jiti = jitiFactory(import.meta.url)
+const {
+  sanitizeRemoteHtml,
+  isSafeRemoteUrl,
+  buildSafeSourceLink,
+  getNotionCoverUrl,
+} = jiti(join(__dirname, '../server/utils/content-security.ts'))
+
+test('sanitizeRemoteHtml removes script tags, inline handlers, and dangerous URL schemes', () => {
+  const dirty = '<div><script>alert(1)</script><img src="x" onerror="alert(1)"><a href="javascript:alert(1)">click</a><a href=javascript:alert(2)>click2</a><img src="data:text/html,<script>alert(3)</script>"><p>safe</p></div>'
+  const clean = sanitizeRemoteHtml(dirty)
+
+  assert.equal(clean.includes('<script'), false)
+  assert.equal(clean.includes('onerror='), false)
+  assert.equal(clean.includes('javascript:'), false)
+  assert.equal(clean.includes('data:text/html'), false)
+  assert.equal(clean.includes('<p>safe</p>'), true)
+})
+
+test('isSafeRemoteUrl accepts public https URLs and rejects local/private targets', () => {
+  assert.equal(isSafeRemoteUrl('https://dev.to/user/post'), true)
+  assert.equal(isSafeRemoteUrl('https://example.com/article'), true)
+  assert.equal(isSafeRemoteUrl('http://127.0.0.1/admin'), false)
+  assert.equal(isSafeRemoteUrl('http://localhost:3000'), false)
+  assert.equal(isSafeRemoteUrl('http://169.254.169.254/latest/meta-data'), false)
+  assert.equal(isSafeRemoteUrl('http://10.0.0.5/internal'), false)
+  assert.equal(isSafeRemoteUrl('javascript:alert(1)'), false)
+  assert.equal(isSafeRemoteUrl('data:text/html,<script>alert(1)</script>'), false)
+})
+
+test('buildSafeSourceLink returns safe markup for valid URLs and empty string for unsafe ones', () => {
+  assert.equal(
+    buildSafeSourceLink('https://dev.to/user/post').startsWith('<p><a href="https://dev.to/user/post"'),
+    true,
+  )
+  assert.equal(buildSafeSourceLink('javascript:alert(1)'), '')
+  assert.equal(buildSafeSourceLink('http://127.0.0.1/test'), '')
+})
+
+test('getNotionCoverUrl reads top-level cover from Notion pages', () => {
+  const page = {
+    cover: {
+      external: { url: 'https://cdn.example.com/cover.png' },
+    },
+    properties: {},
+  }
+
+  assert.equal(getNotionCoverUrl(page), 'https://cdn.example.com/cover.png')
+})


### PR DESCRIPTION
## Description
Fixes the news sync job failing with timeouts/crashes. The `/api/news/sync` endpoint was doing too much synchronous work and making untimeout-guarded external fetch calls, hitting the Netlify function timeout boundary.

## Changes
- **Split sync flow:** separated Notion page creation (`/api/news/sync`) from content scraping (`/api/news/enrich`).
- **Harden execution:** added wall-clock budget guard (22s) inside the Netlify functions and raised toml function timeout to 26s.
- **Fetch timeouts:** added `AbortSignal.timeout` to all outbound fetch calls (HN, dev.to, Notion API).
- **Security:** added `content-security.ts` to sanitize remote HTML, validate URLs to prevent SSRF, and safely build source links.
- **Workflow:** added curl client-side timeouts and wired up the new sequential enrich step.
- **Tests:** added `news-security.test.mjs` to verify the sanitizer and URL guards.